### PR TITLE
chore(src): fix toast alert text color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -195,6 +195,8 @@ form {
   color: #fff0;
   text-align: center;
   border-radius: 4px;
+  border: none;
+  box-shadow: 0 1rem 4rem rgba(0, 0, 0, 0.5);
   width: 60%;
   margin: 0 auto;
   padding: 0.5rem;
@@ -202,15 +204,17 @@ form {
 
 .alert-success {
   background-color: rgb(2, 180, 2);
+  color: white;
 }
 
 .alert-danger {
   background-color: rgb(245, 50, 50);
+  color: white;
 }
 
 .alert__flow {
   position: absolute;
-  top: 0;
+  top: 8px;
   right: 0;
   left: 0;
   margin-left: auto;


### PR DESCRIPTION
## What Is Improved?
I fixed the toast alert text color not contrasting with the background

## Before
![image](https://user-images.githubusercontent.com/59865105/196816364-45681327-f92a-4d23-b749-91daeaee705d.png)
![image](https://user-images.githubusercontent.com/59865105/196816423-4ef28b4f-9056-4f10-bec4-2f16bd2b1f67.png)

## After
![image](https://user-images.githubusercontent.com/59865105/196816543-bafd09ed-be16-463b-8e88-a7835dc70684.png)
![image](https://user-images.githubusercontent.com/59865105/196816575-031207e0-90af-45be-9a76-8e1fce762b89.png)

