### PR TITLE
chore(src): fix icon hover color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -178,15 +178,15 @@ form {
   transition: 0.2s;
 }
 
-  .edit__btn:hover {
-    background-color: green;
-    color: #fff;
-    transition: 0.1s ease-in-out;
+.edit__btn:hover {
+  background-color: green;
+  color: #fff;
+  transition: 0.1s ease-in-out;
 }
 
 .delete__btn:hover {
   background-color: red;
-  color: #fff0;
+  color: #fff;
   transition: 0.1s ease-in-out;
 }
 


### PR DESCRIPTION
## What is Improved?
I fixed the icon hover color not contrasting with the background

## Normal State
![image](https://user-images.githubusercontent.com/59865105/196816976-7b4cabf9-9f46-4254-b0e6-be15d9aef80a.png)

## Hover State Before
![image](https://user-images.githubusercontent.com/59865105/196817076-0be9d00f-09bc-43a3-83ce-2b4326878532.png)

## Hover State After
![image](https://user-images.githubusercontent.com/59865105/196817117-b2231db0-6360-4e52-ba60-d4b2db214ad0.png)
